### PR TITLE
VCST-5014: Fix 20 entries limitation

### DIFF
--- a/src/VirtoCommerce.SqlQueries.Web/Scripts/blades/sql-query-list.html
+++ b/src/VirtoCommerce.SqlQueries.Web/Scripts/blades/sql-query-list.html
@@ -1,3 +1,6 @@
+<div class="blade-static __bottom"
+     ng-if="pageSettings.itemsPerPageCount < pageSettings.totalItems"
+     ng-include="'pagerTemplate.html'"></div>
 <div class="blade-content __xlarge-wide">
   <div class="blade-inner">
     <div class="inner-block">

--- a/src/VirtoCommerce.SqlQueries.Web/Scripts/blades/sql-query-list.js
+++ b/src/VirtoCommerce.SqlQueries.Web/Scripts/blades/sql-query-list.js
@@ -2,11 +2,11 @@ angular.module('VirtoCommerce.SqlQueriesModule')
     .controller('VirtoCommerce.SqlQueriesModule.sqlQueryListController',
         [
             '$scope',
-            'platformWebApp.bladeNavigationService', 'platformWebApp.dialogService', 'uiGridConstants', 'platformWebApp.uiGridHelper',
+            'platformWebApp.bladeNavigationService', 'platformWebApp.dialogService', 'uiGridConstants', 'platformWebApp.uiGridHelper', 'platformWebApp.bladeUtils',
             'VirtoCommerce.SqlQueriesModule.sqlQueriesApi',
             function (
                 $scope,
-                bladeNavigationService, dialogService, uiGridConstants, uiGridHelper,
+                bladeNavigationService, dialogService, uiGridConstants, uiGridHelper, bladeUtils,
                 sqlQueriesApi)
             {
                 $scope.uiGridConstants = uiGridConstants;
@@ -16,14 +16,20 @@ angular.module('VirtoCommerce.SqlQueriesModule')
 
                 blade.refresh = function () {
                     blade.isLoading = true;
-                    sqlQueriesApi.search({}, function (data) {
+                    const searchCriteria = {
+                        skip: ($scope.pageSettings.currentPage - 1) * $scope.pageSettings.itemsPerPageCount,
+                        take: $scope.pageSettings.itemsPerPageCount
+                    };
+                    sqlQueriesApi.search(searchCriteria, function (data) {
                         blade.currentEntities = data.results;
+                        $scope.pageSettings.totalItems = data.totalCount;
                         blade.isLoading = false;
                     }, function (error) {
                         if (error.status === 403) {
                             // Fall back to reports endpoint for users without read permission
-                            sqlQueriesApi.reports({}, function (data) {
+                            sqlQueriesApi.reports(searchCriteria, function (data) {
                                 blade.currentEntities = data.results;
+                                $scope.pageSettings.totalItems = data.totalCount;
                                 blade.isLoading = false;
                             }, function (error2) {
                                 bladeNavigationService.setError('Error ' + error2.status, blade);
@@ -123,7 +129,9 @@ angular.module('VirtoCommerce.SqlQueriesModule')
                     uiGridHelper.initialize($scope, gridOptions);
                 };
 
-                blade.refresh();
+                // Initializes $scope.pageSettings and a $watch on currentPage that calls blade.refresh().
+                // The watcher fires on first digest, so an explicit blade.refresh() is not needed here.
+                bladeUtils.initializePagination($scope);
             }
         ]
     );


### PR DESCRIPTION
## Description
fix: 20 entries limitation

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5014
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.SqlQueries_3.1001.0-pr-11-3db1.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes list loading to use paged `search`/`reports` requests and introduces UI pagination, which could affect list completeness or navigation if paging parameters/total counts don’t match backend behavior.
> 
> **Overview**
> Removes the effective 20-item cap in the SQL queries list by adding **pagination UI** and switching list loading to **paged API calls**.
> 
> `sql-query-list` now computes `skip`/`take` from `pageSettings`, updates `pageSettings.totalItems` from `totalCount`, and initializes pagination via `bladeUtils.initializePagination($scope)` (including the 403 fallback to `reports`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db146aa304dae497bad77975adf92cb9838412e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->