### PR TITLE
fix: apply default parameter values to prevent SqlDateTime overflow on undefined params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -337,3 +337,4 @@ ASALocalRun/
 .nuke
 dist/
 **/Properties/launchSettings.json
+/.serena

--- a/src/VirtoCommerce.SqlQueries.Core/Services/ISqlQueryReportGenerator.cs
+++ b/src/VirtoCommerce.SqlQueries.Core/Services/ISqlQueryReportGenerator.cs
@@ -8,5 +8,10 @@ public interface ISqlQueryReportGenerator
     string Format { get; }
     string ContentType { get; }
 
+    /// <summary>
+    /// Display/order priority. Higher value means higher priority (listed first).
+    /// </summary>
+    int Priority => 0;
+
     SqlQueryReport GenerateReport(DataTable table, SqlQueryReportContext context);
 }

--- a/src/VirtoCommerce.SqlQueries.Data/Services/CsvSqlQueryReportGenerator.cs
+++ b/src/VirtoCommerce.SqlQueries.Data/Services/CsvSqlQueryReportGenerator.cs
@@ -11,6 +11,7 @@ public class CsvSqlQueryReportGenerator : ISqlQueryReportGenerator
 {
     public string Format => "csv";
     public string ContentType => "text/csv";
+    public int Priority => 10;
 
     public virtual SqlQueryReport GenerateReport(DataTable table, SqlQueryReportContext context)
     {

--- a/src/VirtoCommerce.SqlQueries.Data/Services/HtmlSqlQueryReportGenerator.cs
+++ b/src/VirtoCommerce.SqlQueries.Data/Services/HtmlSqlQueryReportGenerator.cs
@@ -12,6 +12,7 @@ public class HtmlSqlQueryReportGenerator : IHtmlSqlQueryReportGenerator
 {
     public string Format => "html";
     public string ContentType => "text/html";
+    public int Priority => 40;
 
     public virtual SqlQueryReport GenerateReport(DataTable table, SqlQueryReportContext context)
     {

--- a/src/VirtoCommerce.SqlQueries.Data/Services/PdfSqlQueryReportGenerator.cs
+++ b/src/VirtoCommerce.SqlQueries.Data/Services/PdfSqlQueryReportGenerator.cs
@@ -12,6 +12,7 @@ public class PdfSqlQueryReportGenerator(IHtmlSqlQueryReportGenerator htmlGenerat
 {
     public string Format => "pdf";
     public string ContentType => "application/pdf";
+    public int Priority => 30;
 
     public virtual SqlQueryReport GenerateReport(DataTable table, SqlQueryReportContext context)
     {

--- a/src/VirtoCommerce.SqlQueries.Data/Services/SqlQueryService.cs
+++ b/src/VirtoCommerce.SqlQueries.Data/Services/SqlQueryService.cs
@@ -168,7 +168,11 @@ public class SqlQueryService(
 
     public virtual IList<string> GetFormats()
     {
-        return generators.Select(x => x.Format).ToList();
+        return generators
+            .OrderByDescending(x => x.Priority)
+            .ThenBy(x => x.Format, StringComparer.OrdinalIgnoreCase)
+            .Select(x => x.Format)
+            .ToList();
     }
 
     public virtual DatabaseInformation GetDatabaseInformation()

--- a/src/VirtoCommerce.SqlQueries.Data/Services/SqlQueryService.cs
+++ b/src/VirtoCommerce.SqlQueries.Data/Services/SqlQueryService.cs
@@ -219,26 +219,17 @@ public class SqlQueryService(
 
     protected virtual object GetParameterValue(SqlQueryParameter parameter)
     {
-        var result = parameter.Value;
+        var isEmpty = parameter.Value is null ||
+            (parameter.Value is string stringValue && string.IsNullOrWhiteSpace(stringValue));
 
-        if (parameter.Type == "Integer")
+        return parameter.Type switch
         {
-            result = Convert.ToInt32(parameter.Value);
-        }
-        else if (parameter.Type == "Decimal")
-        {
-            result = Convert.ToDecimal(parameter.Value);
-        }
-        else if (parameter.Type == "DateTime")
-        {
-            result = Convert.ToDateTime(parameter.Value);
-        }
-        else if (parameter.Type == "Boolean")
-        {
-            result = Convert.ToBoolean(parameter.Value);
-        }
-
-        return result;
+            "Integer" => isEmpty ? 0 : Convert.ToInt32(parameter.Value),
+            "Decimal" => isEmpty ? 0m : Convert.ToDecimal(parameter.Value),
+            "DateTime" => isEmpty ? DateTime.Today : Convert.ToDateTime(parameter.Value),
+            "Boolean" => isEmpty ? false : Convert.ToBoolean(parameter.Value),
+            _ => parameter.Value,
+        };
     }
 
     private static void FillParameters(SqlQuery query, IList<SqlQueryParameter> parameters)

--- a/src/VirtoCommerce.SqlQueries.Data/Services/SqlQueryService.cs
+++ b/src/VirtoCommerce.SqlQueries.Data/Services/SqlQueryService.cs
@@ -227,7 +227,7 @@ public class SqlQueryService(
             "Integer" => isEmpty ? 0 : Convert.ToInt32(parameter.Value),
             "Decimal" => isEmpty ? 0m : Convert.ToDecimal(parameter.Value),
             "DateTime" => isEmpty ? DateTime.Today : Convert.ToDateTime(parameter.Value),
-            "Boolean" => isEmpty ? false : Convert.ToBoolean(parameter.Value),
+            "Boolean" => !isEmpty && Convert.ToBoolean(parameter.Value),
             _ => parameter.Value,
         };
     }

--- a/src/VirtoCommerce.SqlQueries.Data/Services/XlsxSqlQueryReportGenerator.cs
+++ b/src/VirtoCommerce.SqlQueries.Data/Services/XlsxSqlQueryReportGenerator.cs
@@ -16,6 +16,7 @@ public class XlsxSqlQueryReportGenerator() : ISqlQueryReportGenerator
 
     public string Format => "xlsx";
     public string ContentType => "application/vnd.ms-excel";
+    public int Priority => 20;
 
     public virtual SqlQueryReport GenerateReport(DataTable table, SqlQueryReportContext context)
     {

--- a/src/VirtoCommerce.SqlQueries.Web/Scripts/blades/report-execution.js
+++ b/src/VirtoCommerce.SqlQueries.Web/Scripts/blades/report-execution.js
@@ -89,6 +89,32 @@ angular.module('VirtoCommerce.SqlQueriesModule')
                 blade.datepickers[parameter.name] = false;
             });
 
+            //apply default values when not specified
+            blade.parameters.forEach(setDefaultParameterValue);
+
+            function setDefaultParameterValue(parameter) {
+                if (!isEmptyValue(parameter.value)) {
+                    return;
+                }
+
+                switch (parameter.type) {
+                    case 'DateTime': parameter.value = getToday(); break;
+                    case 'Integer':
+                    case 'Decimal': parameter.value = 0; break;
+                    case 'Boolean': parameter.value = false; break;
+                }
+            }
+
+            function getToday() {
+                var today = new Date();
+                today.setHours(0, 0, 0, 0);
+                return today;
+            }
+
+            function isEmptyValue(value) {
+                return angular.isUndefined(value) || value === null || value === '';
+            }
+
             //calls
             initializeToolbar();
             blade.refresh();

--- a/src/VirtoCommerce.SqlQueries.Web/Scripts/blades/report-view.js
+++ b/src/VirtoCommerce.SqlQueries.Web/Scripts/blades/report-view.js
@@ -150,7 +150,12 @@ angular.module('VirtoCommerce.SqlQueriesModule')
                         });
                         var value = existing ? existing.value : null;
                         if (isEmptyValue(value)) {
-                            value = getDefaultParameterValue(param.type);
+                            switch (param.type) {
+                                case 'DateTime': value = getToday(); break;
+                                case 'Integer':
+                                case 'Decimal': value = 0; break;
+                                case 'Boolean': value = false; break;
+                            }
                         }
                         newTestParams.push({
                             name: param.name,
@@ -167,16 +172,6 @@ angular.module('VirtoCommerce.SqlQueriesModule')
                             blade.testDatepickers[param.name] = false;
                         }
                     });
-                }
-
-                function getDefaultParameterValue(type) {
-                    switch (type) {
-                        case 'DateTime': return getToday();
-                        case 'Integer':
-                        case 'Decimal': return 0;
-                        case 'Boolean': return false;
-                        default: return null;
-                    }
                 }
 
                 function getToday() {

--- a/src/VirtoCommerce.SqlQueries.Web/Scripts/blades/report-view.js
+++ b/src/VirtoCommerce.SqlQueries.Web/Scripts/blades/report-view.js
@@ -148,10 +148,14 @@ angular.module('VirtoCommerce.SqlQueriesModule')
                         var existing = _.find(blade.testParameters, function (tp) {
                             return tp.name === param.name;
                         });
+                        var value = existing ? existing.value : null;
+                        if (isEmptyValue(value)) {
+                            value = getDefaultParameterValue(param.type);
+                        }
                         newTestParams.push({
                             name: param.name,
                             type: param.type,
-                            value: existing ? existing.value : null
+                            value: value
                         });
                     });
 
@@ -163,6 +167,26 @@ angular.module('VirtoCommerce.SqlQueriesModule')
                             blade.testDatepickers[param.name] = false;
                         }
                     });
+                }
+
+                function getDefaultParameterValue(type) {
+                    switch (type) {
+                        case 'DateTime': return getToday();
+                        case 'Integer':
+                        case 'Decimal': return 0;
+                        case 'Boolean': return false;
+                        default: return null;
+                    }
+                }
+
+                function getToday() {
+                    var today = new Date();
+                    today.setHours(0, 0, 0, 0);
+                    return today;
+                }
+
+                function isEmptyValue(value) {
+                    return angular.isUndefined(value) || value === null || value === '';
                 }
 
                 function loadExportFormats() {

--- a/src/VirtoCommerce.SqlQueries.Web/Scripts/blades/sql-query-details.js
+++ b/src/VirtoCommerce.SqlQueries.Web/Scripts/blades/sql-query-details.js
@@ -60,6 +60,11 @@ angular.module('VirtoCommerce.SqlQueriesModule')
                         blade.connectionStringNames = information.connectionStringNames;
                         blade.databaseProvider = information.databaseProvider;
                         blade.editorOptions.mode = getSqlMimeType(information.databaseProvider);
+
+                        // preselect the only available connection string to save a click
+                        if (!blade.currentEntity.connectionStringName && blade.connectionStringNames.length === 1) {
+                            blade.currentEntity.connectionStringName = blade.connectionStringNames[0];
+                        }
                     });
                 };
 

--- a/src/VirtoCommerce.SqlQueries.Web/Scripts/blades/sql-query-details.js
+++ b/src/VirtoCommerce.SqlQueries.Web/Scripts/blades/sql-query-details.js
@@ -182,6 +182,32 @@ angular.module('VirtoCommerce.SqlQueriesModule')
                     });
                 };
 
+                $scope.syncTestParamDefaults = function () {
+                    var currentParams = blade.currentEntity.parameters || [];
+                    currentParams.forEach(function (param) {
+                        if (!isEmptyValue(blade.testParamValues[param.name])) {
+                            return;
+                        }
+
+                        switch (param.type) {
+                            case 'DateTime': blade.testParamValues[param.name] = getToday(); break;
+                            case 'Integer':
+                            case 'Decimal': blade.testParamValues[param.name] = 0; break;
+                            case 'Boolean': blade.testParamValues[param.name] = false; break;
+                        }
+                    });
+                };
+
+                function isEmptyValue(value) {
+                    return angular.isUndefined(value) || value === null || value === '';
+                }
+
+                function getToday() {
+                    var today = new Date();
+                    today.setHours(0, 0, 0, 0);
+                    return today;
+                }
+
                 $scope.runTestQuery = function () {
                     blade.testError = null;
                     blade.testResults = null;
@@ -237,6 +263,7 @@ angular.module('VirtoCommerce.SqlQueriesModule')
 
                 $scope.$watchCollection('blade.currentEntity.parameters', function () {
                     $scope.syncTestDatepickers();
+                    $scope.syncTestParamDefaults();
                 });
 
                 //local functions

--- a/tests/VirtoCommerce.SqlQueries.Tests/VirtoCommerce.SqlQueries.Tests.csproj
+++ b/tests/VirtoCommerce.SqlQueries.Tests/VirtoCommerce.SqlQueries.Tests.csproj
@@ -8,7 +8,7 @@
     <SonarQubeTestProject>true</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description
fix: apply default parameter values to prevent SqlDateTime overflow on undefined params

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.SqlQueries_3.1003.0-pr-14-fde8.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Empty parameters now bind as 0/today/false instead of null/DBNull, which can change query results for reports that relied on unset values; DateTime default uses server-local `DateTime.Today`.
> 
> **Overview**
> **Fixes undefined/empty SQL query parameters** by applying typed defaults on the server and in the admin UI, avoiding failures such as SqlDateTime overflow when DateTime params are left unset.
> 
> `SqlQueryService.GetParameterValue` now treats null/whitespace as empty and maps **Integer/Decimal/DateTime/Boolean** to `0`, `0m`, `DateTime.Today`, and `false` respectively. Report execution, report view, and SQL query detail blades apply the same defaults before test runs and exports.
> 
> **UX tweaks:** export formats are ordered via new `Priority` on `ISqlQueryReportGenerator` (html first); a single configured connection string is auto-selected on query details. Minor housekeeping: ignore `/.serena`, bump `coverlet.collector` to 10.0.1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fde855d5f974819185635dcd3d820639f22e0448. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->