### PR TITLE
feat: Two project-scoped skills under .claude/skills/ for automating the SQL Queries module's reporting via its REST API.

### DIFF
--- a/.claude/skills/DEMO.md
+++ b/.claude/skills/DEMO.md
@@ -1,0 +1,180 @@
+# Demo: Automating Virto SQL Queries reports with Claude Code
+
+A tight live-terminal demo of the two-skill story: an **admin** authors a governed SQL report
+by natural language, then a **business user** runs and exports it — same permission boundary
+the platform already enforces, no SQL typed by hand.
+
+Two skills ship in this repo under `.claude/skills/`:
+
+- **`vc-sql-queries-admin`** — author & lifecycle (create / update / test / delete). Needs
+  `sql-queries:create` / `:update` / `:delete` / `:read`.
+- **`vc-sql-queries-business`** — run & export only. Needs `sql-queries:access` + `:read`.
+  Never writes SQL; structurally can't author or mutate.
+
+---
+
+## Setup (off-camera, before you start)
+
+- Repo cloned with the skills committed at `.claude/skills/`. Open Claude Code in the repo
+  root so it picks up `CLAUDE.md` and both skills.
+- Environment configured locally (do **not** commit secrets). Either a `.claude/settings.local.json`
+  `env` block (gitignored) or persistent user env vars:
+  - `VC_PLATFORM_URL` — e.g. `https://localhost:5001`
+  - `VC_USER`, `VC_PASS` — credentials for the bearer token
+- A read-only `SqlQueries.`-prefixed connection string already configured on the instance
+  (verified: `SqlQueries.VirtoCommerce`).
+- Run the whole thing once end-to-end before recording (see **Rehearsal checklist**).
+
+> ⚠️ **The one wording fix vs. earlier drafts:** an optional parameter is **left blank**, never
+> *removed from the request*. Dropping a declared parameter makes the database return
+> `Must declare the scalar variable @<name>` (HTTP 500). A blank/`null` value is accepted —
+> the backend substitutes a type default (`DateTime` → today, `Integer`/`Decimal` → `0`,
+> `Boolean` → `false`). So "blank" means **use the default**, not SQL `NULL`.
+
+---
+
+## 0:00 — Frame it (20 sec)
+
+> "Two Claude Code skills ship inside this module repo. One lets an admin *author* governed SQL
+> reports; the other lets a business user *run and export* them — no SQL, no DBA ticket. Same
+> permission model the platform already enforces. Let me show both, live."
+
+Prove the skills loaded — type:
+
+```
+/skills
+```
+
+Point at `vc-sql-queries-admin` and `vc-sql-queries-business`. *"These came from the repo,
+committed in git — anyone who clones gets them."*
+
+---
+
+## 0:30 — Act 1: Admin authors a report (≈2 min)
+
+Plain-English request, no SQL:
+
+```
+Create a SQL Queries report that totals orders per store since an optional start date.
+Test it before saving.
+```
+
+**Narrate as the skill drives the order:**
+- It reads `vc-sql-queries-admin`, then `GET /database-information` to confirm the provider
+  (SqlServer) and the `SqlQueries.VirtoCommerce` connection string. *"Discovering the
+  environment, not guessing."*
+- It drafts a read-only `SELECT … GROUP BY StoreId` with `(@FromDate IS NULL OR CreatedDate >= @FromDate)`.
+  *"Parameterized, read-only — it never concatenates values into SQL."*
+- It calls `POST /execute-preview` **twice** — once with a date value, once with `FromDate`
+  **present but blank**. *"Notice it keeps the parameter in the request and just leaves the
+  value empty — the backend defaults a blank date to today. Drop the parameter entirely and
+  SQL Server would reject it."* Point at the returned `columns` / `totalRowCount` /
+  `executionTimeMs`.
+- It shows the final report definition and **waits for confirmation** before saving. *"It won't
+  persist shared state without a yes."*
+
+Confirm:
+
+```
+Looks good — save it.
+```
+
+It `POST /api/sql-queries` to create and reports the new report `id`. **Money line:** *"From
+one sentence to a governed, parameterized, previewed report — and it never wrote a single
+mutating statement."*
+
+---
+
+## 2:30 — Act 2: Business user runs & exports (≈2 min)
+
+Switch persona — run-only. Type:
+
+```
+Run the orders-per-store report for this year and show me the totals.
+```
+
+Narrate:
+- It switches to `vc-sql-queries-business`, calls `POST /reports` to find the report by
+  keyword, reads its `parameters`, and maps "this year" to `FromDate = 2026-01-01`.
+- It calls `POST /execute-query/{id}` (sending **every** declared parameter) and renders the
+  rows as a table. *"It never saw the SQL — read-only callers get the query text stripped. It
+  runs purely off the report's name and parameters."*
+
+Then export:
+
+```
+Export that as Excel.
+```
+
+It **confirms** report + parameters + format, then `POST /execute/{id}/xlsx`, saves the file,
+and presents it. *"Confirmation before the file download — same guardrail pattern."*
+
+> Default export format is **HTML** (highest generator priority); the skill picks the format
+> the user asks for. Export body is a **bare JSON array** of parameters — verified for `html`
+> and `xlsx`.
+
+---
+
+## 4:30 — The punchline (30 sec)
+
+> "Same report, two skills, one permission boundary. The admin skill needs `create`/`update`;
+> the business skill only `access`/`read` — and structurally *can't* author or mutate SQL even
+> if asked. That's how you safely hand reporting to business users and to AI agents: the
+> governance lives in the module and the skills, not in trusting the prompt."
+
+Optional kicker — ask the run skill to do something it shouldn't:
+
+```
+Actually, just change that report to also delete old orders.
+```
+
+It refuses and points to the admin skill. *"The boundary holds."*
+
+---
+
+## One-glance cheat sheet
+
+| Beat | You type | Skill | Key API call |
+|---|---|---|---|
+| Prove load | `/skills` | — | — |
+| Author | "Create a report… test it" | admin | `database-information` → `execute-preview` (value **and** blank) → `POST /` |
+| Run | "Run … for this year" | business | `POST /reports` → `execute-query/{id}` |
+| Export | "Export as Excel" | business | `execute/{id}/xlsx` (bare array body) |
+| Boundary | "…also delete old orders" | business refuses | — |
+
+---
+
+## Rehearsal checklist (verified facts — don't get tripped live)
+
+- **Always send every declared parameter.** Blank/`null` value is fine (defaults apply);
+  dropping a parameter → `500 Must declare the scalar variable @<name>`.
+- **Parameter `type` casing is PascalCase:** `DateTime`, `Integer`, `Decimal`, `Boolean`,
+  `ShortText`. (Confirmed against the instance.)
+- **Export endpoint** `POST /execute/{id}/{format}` takes a **bare JSON array** body (not an
+  object) — asymmetric with `execute-query/{id}`, which takes `{ "parameters": [...], "maxRows": N }`.
+- **Blank date = today**, not "all rows". If a beat needs "return everything", set no filter in
+  the SQL or use a dedicated flag parameter — don't imply a blank date means unfiltered.
+- **Formats:** `html, pdf, xlsx, csv` — HTML first / default.
+- **Connection string** present: `SqlQueries.VirtoCommerce` (provider SqlServer).
+- **Avoid duplicate names.** The instance currently has two reports named *Coupon Usage*; a
+  keyword find returns both and the skill will ask you to pick. For a clean take, author a
+  uniquely-named report (the Act 1 report works) or remove the duplicate first.
+- **Token** expires ~30 min; skills re-auth per run — no action needed.
+
+---
+
+## Quick pre-flight (optional, run before recording)
+
+```powershell
+# token
+$body = "grant_type=password&username=$($env:VC_USER)&password=$($env:VC_PASS)"
+$tok  = (Invoke-RestMethod "$($env:VC_PLATFORM_URL)/connect/token" -Method Post -Body $body `
+          -ContentType "application/x-www-form-urlencoded" -SkipCertificateCheck).access_token
+$base = "$($env:VC_PLATFORM_URL)/api/sql-queries"; $H = @{ Authorization = "Bearer $tok" }
+
+# prerequisites + listings
+Invoke-RestMethod "$base/database-information" -Headers $H -SkipCertificateCheck
+Invoke-RestMethod "$base/formats"              -Headers $H -SkipCertificateCheck
+Invoke-RestMethod "$base/reports" -Method Post -Headers $H -ContentType application/json `
+  -Body '{"take":50}' -SkipCertificateCheck | Select-Object -Expand results | Format-Table name,id
+```

--- a/.claude/skills/vc-sql-queries-admin/SKILL.md
+++ b/.claude/skills/vc-sql-queries-admin/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: vc-sql-queries-admin
+description: >
+  Author and manage reusable reports in the Virto Commerce SQL Queries module via its
+  REST API. Use this skill when the user wants to CREATE, UPDATE, TEST/PREVIEW, search,
+  or DELETE saved SQL query reports — i.e. report authoring and lifecycle management for
+  an administrator. Triggers include: "create a report", "add a SQL query", "edit the
+  report query", "test this query before saving", "add a parameter to the report",
+  "list all reports", "delete a report". Requires sql-queries:create / :update / :delete
+  / :read permissions. Do NOT use this skill for merely running an existing report to get
+  data — that is vc-sql-queries-business. Do NOT use it to design schema-level changes to
+  the platform database.
+---
+
+# Virto Commerce SQL Queries — Administrator (Report Authoring) Skill
+
+You manage the lifecycle of reusable SQL query reports through the SQL Queries module REST
+API. Your job is to help an administrator design a safe, parameterized query, validate it
+with a live preview, and persist it so business users can run it later.
+
+For authentication, base path, exact endpoint table, and JSON model shapes, read
+`references/api.md` in this skill folder. This file covers *behaviour and rules*.
+
+## Golden rules
+
+1. **Read-only data, by design.** Saved reports run against a dedicated **read-only**
+   connection string whose name is prefixed with `SqlQueries.` (e.g. `SqlQueries.VirtoCommerce`).
+   Never author a query that writes data (`INSERT`/`UPDATE`/`DELETE`/`MERGE`/DDL). Reports
+   are for reading and aggregation only. If a user asks for a mutating query, refuse and
+   explain that the module is read-only.
+2. **Always preview before you save.** Use `POST /execute-preview` to validate syntax, column
+   shape, and row count against real data BEFORE creating or updating a saved report.
+3. **Parameterize, never interpolate.** Pass user-supplied values as `parameters`, never by
+   string-concatenating values into the `query` text. The query references them with the
+   provider's parameter syntax (`@Name` for SQL Server).
+4. **Send every declared parameter; blanks become type defaults.** The backend adds a DB
+   parameter only for entries present in the request, so a request must include **all**
+   declared parameters — dropping one makes the database fail with `Must declare the scalar
+   variable @<name>`. For a value left unspecified, send the parameter with an empty/`null`
+   `value`: the backend substitutes a type default (`DateTime` → today, `Integer`/`Decimal` →
+   `0`, `Boolean` → `false`). Because of this, an unset `DateTime` no longer causes a
+   `SqlDateTime overflow`, **but** a blank value now means "use the default", not SQL `NULL`.
+   A `(@FromDate IS NULL OR SomeDate >= @FromDate)` guard is still good defensive practice, yet
+   its `IS NULL` branch will not fire for a blank `DateTime`/number/bool (it arrives as the
+   default, not `NULL`). If a report genuinely needs an explicit "no filter / all rows" option,
+   model it with a dedicated flag parameter rather than relying on a blank value.
+5. **Confirm before destructive or persisted actions.** Creating, updating, and deleting
+   saved reports change shared state other users depend on. State exactly what you are about
+   to do (name, connection string, parameter list, and a one-line summary of the query) and
+   get a clear yes before calling Create / Update / Delete. Never delete without explicit
+   confirmation of the specific report name(s).
+
+## Standard authoring workflow
+
+1. **Clarify intent.** Confirm the business question, the tables, and which inputs should be
+   parameters vs. fixed.
+2. **Discover the environment.** `GET /database-information` to confirm the provider
+   (SQL Server / MySQL / PostgreSQL) and the available `SqlQueries.`-prefixed connection
+   string name. Provider affects parameter syntax and functions.
+3. **Draft the SQL.** Read-only `SELECT` only. Parameterize inputs. Follow golden rule 4 for
+   optional parameters (blanks arrive as type defaults, not `NULL`).
+4. **Preview against real data.** `POST /execute-preview` with representative parameter values,
+   AND once with optional params left **empty** (present in the array with an empty/`null`
+   `value` — never removed), to prove both paths work and the default substitution behaves as
+   intended. Inspect `columns`, `totalRowCount`, `isTruncated`, `executionTimeMs`. If execution
+   time is high or the row count is huge, suggest adding a parameter or a date bound before saving.
+5. **Show the user the final report definition** (name, connection string, parameters, query)
+   and get confirmation.
+6. **Persist.** `POST /` to create, or `PUT /` (include `id`) to update.
+7. **Hand off.** Remind the user that business users need `sql-queries:access` +
+   `sql-queries:read` to find and run it, and that running/exporting is vc-sql-queries-business.
+
+## Worked example (generic)
+
+User: "Create a report that totals orders per store since a given date, where the date is optional."
+
+1. `GET /database-information` → provider = SqlServer, connection = `SqlQueries.VirtoCommerce`.
+2. Draft (note the nullable guard on `@FromDate`):
+   ```sql
+   SELECT StoreId,
+          COUNT(*)   AS TotalOrders,
+          SUM(Total) AS TotalOrderAmount
+   FROM CustomerOrder
+   WHERE (@FromDate IS NULL OR CreatedDate >= @FromDate)
+   GROUP BY StoreId
+   ORDER BY StoreId;
+   ```
+3. Preview twice — once with `value` set, once with the parameter present but `value` empty
+   (the backend defaults a blank `DateTime` to today) — to confirm both paths work. Do not
+   remove the parameter from the array, or the database returns `Must declare the scalar
+   variable @FromDate`.
+4. Confirm with the user, then `POST /api/sql-queries` with the report definition.
+5. Report the new `id` back to the user.
+
+## Safety & error handling
+
+- **Never** author or run mutating SQL or DDL. SELECT/CTE/aggregation only.
+- **Never** embed secrets, raw connection strings, or credentials in the `query` text or in
+  output. Reference connection strings by their configured name only.
+- On `Must declare the scalar variable @<name>`: a declared parameter was dropped from the
+  request. Re-send with all declared parameters present (empty/`null` value is fine — the
+  backend defaults it). This is the most common run-time error now.
+- On `SqlDateTime overflow`: a caller passed an explicit out-of-range date (blank values are
+  defaulted to today and won't overflow). Re-preview with an in-range value; if a report needs
+  to treat a blank date specially, model it explicitly rather than relying on `NULL`.
+- On 401/403: surface the missing permission; do not retry blindly.
+- If a preview returns a database error, show the user the database error verbatim (it is not
+  sensitive) and propose a corrected query.
+- Keep `maxRows` modest (default 100) for previews; previews validate, they don't bulk-export.

--- a/.claude/skills/vc-sql-queries-admin/references/api.md
+++ b/.claude/skills/vc-sql-queries-admin/references/api.md
@@ -1,0 +1,159 @@
+# SQL Queries Module — REST API Reference
+
+Verified against `VirtoCommerce.SqlQueries.Web/Controllers/Api/SqlQueriesController.cs`
+and the Core model classes. Field names and routes below are taken from source.
+
+## Authentication
+
+Acquire a platform bearer token once and reuse it:
+
+```
+POST {platformUrl}/connect/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=password&username={user}&password={password}
+```
+
+Send the returned `access_token` as `Authorization: Bearer {token}` on every call.
+Treat the token as a secret: never print, log, or write it to a file. On 401/403, stop and
+report the missing permission — do not retry blindly.
+
+## Base path
+
+```
+{platformUrl}/api/sql-queries
+```
+
+## Endpoints
+
+| Action | Method & route | Permission |
+|---|---|---|
+| Get one report by id | `GET /{id}` | `sql-queries:read` |
+| Search reports | `POST /search` | `sql-queries:read` |
+| List reports (query text stripped) | `POST /reports` | `sql-queries:read` |
+| Create report | `POST /` | `sql-queries:create` |
+| Update report | `PUT /` | `sql-queries:update` |
+| Delete report(s) | `DELETE /?ids={id}&ids={id}` | `sql-queries:delete` |
+| Preview / test an arbitrary query | `POST /execute-preview` | `sql-queries:create` AND `:update` |
+| Run a saved report → rows (JSON) | `POST /execute-query/{id}` | `sql-queries:read` |
+| Run a saved report → downloadable file | `POST /execute/{id}/{format}` | `sql-queries:read` |
+| List export formats | `GET /formats` | (authenticated) |
+| DB providers / connection info | `GET /database-information` | `sql-queries:read` |
+
+Notes:
+- `GET /{id}` and `POST /search` blank out the `query` text for callers lacking
+  create/update permission. This is expected for business users.
+- `POST /reports` always strips `query` text (it's the run-only listing).
+
+## Permission names (from module.manifest localization)
+
+`sql-queries:access`, `sql-queries:create`, `sql-queries:read`, `sql-queries:update`,
+`sql-queries:delete`, `sql-queries:reports`.
+
+## Model shapes (exact field names)
+
+### SqlQuery (the saved report)
+```json
+{
+  "id": "string (omit on create)",
+  "name": "string (required)",
+  "description": "string",
+  "query": "string (required, the SQL text)",
+  "connectionStringName": "string (required, e.g. 'SqlQueries.VirtoCommerce')",
+  "parameters": [ { "name": "FromDate", "type": "DateTime" } ]
+}
+```
+Also carries audit fields on read: `createdBy`, `createdDate`, `modifiedBy`, `modifiedDate`.
+
+### SqlQueryParameter
+```json
+{ "id": "string (optional)", "name": "string", "type": "string", "value": <any> }
+```
+- On a **saved report** a parameter needs only `name` + `type` (it defines the parameter).
+- When **previewing/running** a parameter carries a `value`.
+- Parameter `type` values (per the module): `ShortText`, `DateTime`, `Boolean`, `Integer`,
+  `Decimal`. **Verify canonical casing in this environment** (the type is stored as a free
+  string); confirm via the parameter-type dropdown or an existing saved report.
+
+### SqlQueryPreviewRequest — body for `POST /execute-preview`
+```json
+{
+  "query": "string",
+  "connectionStringName": "string",
+  "parameters": [ { "name": "FromDate", "type": "DateTime", "value": "2026-01-01" } ],
+  "maxRows": 100
+}
+```
+
+### SqlQueryExecuteRequest — body for `POST /execute-query/{id}`
+```json
+{
+  "parameters": [ { "name": "FromDate", "type": "DateTime", "value": "2026-01-01" } ],
+  "maxRows": 100
+}
+```
+
+### SqlQueryExecuteResult — response of preview and execute-query
+```json
+{
+  "columns": [ { "name": "StoreId", "type": "string" } ],
+  "rows": [ ["Store-A", 1240] ],
+  "totalRowCount": 2,
+  "isTruncated": false,
+  "executionTimeMs": 35
+}
+```
+Render `rows` against `columns`. Use `isTruncated` to warn that the view was capped at `maxRows`.
+
+### Run-for-file — `POST /execute/{id}/{format}`
+**IMPORTANT — different body shape.** The body is the **bare parameter list**, not wrapped
+in an object:
+```json
+[ { "name": "FromDate", "type": "DateTime", "value": "2026-01-01" } ]
+```
+`{format}` is one of the values from `GET /formats` (typically `html`, `pdf`, `csv`, `xlsx`).
+The response is the file bytes; the platform names it `{ReportName}_{yyyy-MM-dd}.{format}`.
+
+### Search criteria — body for `POST /search` and `POST /reports`
+Standard Virto search criteria. An empty body `{}` returns the default page. Narrow with a
+keyword and paging, e.g. `{ "keyword": "orders", "skip": 0, "take": 50 }`. Response is
+`{ "results": [SqlQuery], "totalCount": <int> }`.
+
+## curl quick reference
+
+```bash
+# 1. token
+TOKEN=$(curl -s -X POST "$PLATFORM/connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=password&username=$USER&password=$PASS" | jq -r .access_token)
+
+# 2. list runnable reports
+curl -s -X POST "$PLATFORM/api/sql-queries/reports" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"keyword":"orders","take":50}'
+
+# 3. run a report for rows
+curl -s -X POST "$PLATFORM/api/sql-queries/execute-query/$ID" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"parameters":[{"name":"FromDate","type":"DateTime","value":"2026-01-01"}],"maxRows":100}'
+
+# 4. export to xlsx (note: bare array body)
+curl -s -X POST "$PLATFORM/api/sql-queries/execute/$ID/xlsx" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '[{"name":"FromDate","type":"DateTime","value":"2026-01-01"}]' \
+  -o report.xlsx
+```
+
+## PowerShell quick reference (Windows)
+
+```powershell
+$body = "grant_type=password&username=$env:VC_USER&password=$env:VC_PASS"
+$token = (Invoke-RestMethod -Method Post -Uri "$Platform/connect/token" `
+  -ContentType "application/x-www-form-urlencoded" -Body $body).access_token
+$headers = @{ Authorization = "Bearer $token" }
+
+# run a report for rows
+Invoke-RestMethod -Method Post -Uri "$Platform/api/sql-queries/execute-query/$id" `
+  -Headers $headers -ContentType "application/json" `
+  -Body '{"parameters":[{"name":"FromDate","type":"DateTime","value":"2026-01-01"}],"maxRows":100}'
+```

--- a/.claude/skills/vc-sql-queries-business/SKILL.md
+++ b/.claude/skills/vc-sql-queries-business/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: vc-sql-queries-business
+description: >
+  Run existing reports in the Virto Commerce SQL Queries module via its REST API and return
+  or export the results. Use this skill when the user wants to GET DATA from a report that
+  already exists — i.e. find a report, run it with parameter values, read the rows, and
+  optionally export to CSV/XLSX/PDF/HTML. Triggers include: "run the X report", "what does
+  the orders report show for last month", "export the report to Excel", "give me the numbers
+  from <report>", "which reports can I run". Requires sql-queries:access and sql-queries:read.
+  Do NOT use this skill to create, edit, or delete reports or to author SQL — that is
+  vc-sql-queries-admin. This skill never writes SQL; it only runs reports an admin already saved.
+---
+
+# Virto Commerce SQL Queries — Business User (Run & Export) Skill
+
+You help a business user get answers from reports an administrator has already created. You
+locate the right saved report, run it with the values the user provides, present the results,
+and export to a file format when asked. **You never write or change SQL and never create,
+edit, or delete reports.**
+
+For authentication, base path, exact endpoint table, and JSON model shapes, read
+`references/api.md` in this skill folder. This file covers *behaviour and rules*.
+
+## Golden rules
+
+1. **Run only existing reports.** Find a saved report by name/id and execute it by id. If no
+   suitable report exists, say so and suggest the user ask an administrator to create one —
+   do not attempt to author SQL yourself.
+2. **You will not see query text.** With read-only permissions the API strips the `query`
+   field from reports. That is expected. Work from the report `name`, `description`, and its
+   declared `parameters`.
+3. **Always send every declared parameter.** Read the report's `parameters` (each has `name`
+   + `type`) and include **all** of them in the request, by name, as typed values. Ask the
+   user only for the values that matter. For a value the user does not specify, send the
+   parameter with an empty/`null` `value` — the backend applies a type default (`DateTime` →
+   today, `Integer`/`Decimal` → `0`, `Boolean` → `false`). **Never drop a declared parameter
+   from the array**: omitting it makes the database fail with `Must declare the scalar variable
+   @<name>`. (A blank optional value therefore means "use the default", not "return all rows".)
+4. **Confirm before exporting a file.** Generating an export downloads a file. State the
+   report name, the parameter values, and the format, and get a clear yes before calling the
+   export endpoint. (Reading rows in-session via execute-query does not need a file confirmation.)
+5. **Present results clearly and don't over-fetch.** Use a sensible `maxRows` for on-screen
+   reads. If `isTruncated` is true, tell the user the view was capped and offer an export for
+   the full set.
+
+## Standard run workflow
+
+1. **Find the report.** `POST /reports` (optionally with a `keyword`). If several match,
+   show names + descriptions and let the user pick. If none match, say so and stop — suggest
+   an administrator create the report.
+2. **Inspect parameters.** From the chosen report's `parameters`, determine the needed inputs.
+   Ask the user for the values that matter, but always send **every** declared parameter in
+   the request — for any the user doesn't specify, send an empty/`null` `value` and let the
+   backend default apply (today / `0` / `false`).
+3. **Run for rows.** `POST /execute-query/{id}` with the parameter values and a reasonable
+   `maxRows`. Present the result as a table.
+4. **Handle truncation.** If `isTruncated` is true, tell the user the view was capped at
+   `maxRows`; offer to export the full result.
+5. **Export on request (with confirmation).** Confirm report name + parameters + format, then
+   `POST /execute/{id}/{format}`, save the returned file, and present it.
+
+## Worked example (generic)
+
+User: "Run the orders-per-store report for this year and give me the totals."
+
+1. `POST /api/sql-queries/reports` with `{ "keyword": "orders per store" }` → one match,
+   id `abc123`, with a `FromDate` (DateTime) parameter.
+2. The user gave a date intent ("this year") → set `FromDate` to Jan 1 of the current year.
+3. Run for rows:
+   ```json
+   POST /api/sql-queries/execute-query/abc123
+   { "parameters": [ { "name": "FromDate", "type": "DateTime", "value": "2026-01-01" } ],
+     "maxRows": 100 }
+   ```
+4. Render `columns`/`rows` as a table. If `isTruncated`, offer an export.
+5. If the user then says "send me that as Excel", confirm and:
+   ```json
+   POST /api/sql-queries/execute/abc123/xlsx
+   [ { "name": "FromDate", "type": "DateTime", "value": "2026-01-01" } ]
+   ```
+   Save the file and present it.
+
+## Safety & error handling
+
+- Never create, update, or delete reports, and never craft or modify SQL. If asked, explain
+  that authoring is an administrator function (vc-sql-queries-admin).
+- Never print or store the bearer token.
+- On 401/403: report the missing `sql-queries:access`/`:read` permission and stop.
+- If running a report returns `Must declare the scalar variable @<name>`, you dropped a
+  declared parameter from the request. Re-send with **all** declared parameters present
+  (empty/`null` value is fine — the backend defaults it). Do not rewrite the query.
+- If running a report returns another database error, do not try to rewrite the query. Re-run
+  with an explicit value for the parameter the report expects; if it still fails, tell the
+  user the report needs an administrator to fix it.
+- Respect the user's chosen values; do not silently substitute parameters they explicitly set.

--- a/.claude/skills/vc-sql-queries-business/references/api.md
+++ b/.claude/skills/vc-sql-queries-business/references/api.md
@@ -1,0 +1,159 @@
+# SQL Queries Module — REST API Reference
+
+Verified against `VirtoCommerce.SqlQueries.Web/Controllers/Api/SqlQueriesController.cs`
+and the Core model classes. Field names and routes below are taken from source.
+
+## Authentication
+
+Acquire a platform bearer token once and reuse it:
+
+```
+POST {platformUrl}/connect/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=password&username={user}&password={password}
+```
+
+Send the returned `access_token` as `Authorization: Bearer {token}` on every call.
+Treat the token as a secret: never print, log, or write it to a file. On 401/403, stop and
+report the missing permission — do not retry blindly.
+
+## Base path
+
+```
+{platformUrl}/api/sql-queries
+```
+
+## Endpoints
+
+| Action | Method & route | Permission |
+|---|---|---|
+| Get one report by id | `GET /{id}` | `sql-queries:read` |
+| Search reports | `POST /search` | `sql-queries:read` |
+| List reports (query text stripped) | `POST /reports` | `sql-queries:read` |
+| Create report | `POST /` | `sql-queries:create` |
+| Update report | `PUT /` | `sql-queries:update` |
+| Delete report(s) | `DELETE /?ids={id}&ids={id}` | `sql-queries:delete` |
+| Preview / test an arbitrary query | `POST /execute-preview` | `sql-queries:create` AND `:update` |
+| Run a saved report → rows (JSON) | `POST /execute-query/{id}` | `sql-queries:read` |
+| Run a saved report → downloadable file | `POST /execute/{id}/{format}` | `sql-queries:read` |
+| List export formats | `GET /formats` | (authenticated) |
+| DB providers / connection info | `GET /database-information` | `sql-queries:read` |
+
+Notes:
+- `GET /{id}` and `POST /search` blank out the `query` text for callers lacking
+  create/update permission. This is expected for business users.
+- `POST /reports` always strips `query` text (it's the run-only listing).
+
+## Permission names (from module.manifest localization)
+
+`sql-queries:access`, `sql-queries:create`, `sql-queries:read`, `sql-queries:update`,
+`sql-queries:delete`, `sql-queries:reports`.
+
+## Model shapes (exact field names)
+
+### SqlQuery (the saved report)
+```json
+{
+  "id": "string (omit on create)",
+  "name": "string (required)",
+  "description": "string",
+  "query": "string (required, the SQL text)",
+  "connectionStringName": "string (required, e.g. 'SqlQueries.VirtoCommerce')",
+  "parameters": [ { "name": "FromDate", "type": "DateTime" } ]
+}
+```
+Also carries audit fields on read: `createdBy`, `createdDate`, `modifiedBy`, `modifiedDate`.
+
+### SqlQueryParameter
+```json
+{ "id": "string (optional)", "name": "string", "type": "string", "value": <any> }
+```
+- On a **saved report** a parameter needs only `name` + `type` (it defines the parameter).
+- When **previewing/running** a parameter carries a `value`.
+- Parameter `type` values (per the module): `ShortText`, `DateTime`, `Boolean`, `Integer`,
+  `Decimal`. **Verify canonical casing in this environment** (the type is stored as a free
+  string); confirm via the parameter-type dropdown or an existing saved report.
+
+### SqlQueryPreviewRequest — body for `POST /execute-preview`
+```json
+{
+  "query": "string",
+  "connectionStringName": "string",
+  "parameters": [ { "name": "FromDate", "type": "DateTime", "value": "2026-01-01" } ],
+  "maxRows": 100
+}
+```
+
+### SqlQueryExecuteRequest — body for `POST /execute-query/{id}`
+```json
+{
+  "parameters": [ { "name": "FromDate", "type": "DateTime", "value": "2026-01-01" } ],
+  "maxRows": 100
+}
+```
+
+### SqlQueryExecuteResult — response of preview and execute-query
+```json
+{
+  "columns": [ { "name": "StoreId", "type": "string" } ],
+  "rows": [ ["Store-A", 1240] ],
+  "totalRowCount": 2,
+  "isTruncated": false,
+  "executionTimeMs": 35
+}
+```
+Render `rows` against `columns`. Use `isTruncated` to warn that the view was capped at `maxRows`.
+
+### Run-for-file — `POST /execute/{id}/{format}`
+**IMPORTANT — different body shape.** The body is the **bare parameter list**, not wrapped
+in an object:
+```json
+[ { "name": "FromDate", "type": "DateTime", "value": "2026-01-01" } ]
+```
+`{format}` is one of the values from `GET /formats` (typically `html`, `pdf`, `csv`, `xlsx`).
+The response is the file bytes; the platform names it `{ReportName}_{yyyy-MM-dd}.{format}`.
+
+### Search criteria — body for `POST /search` and `POST /reports`
+Standard Virto search criteria. An empty body `{}` returns the default page. Narrow with a
+keyword and paging, e.g. `{ "keyword": "orders", "skip": 0, "take": 50 }`. Response is
+`{ "results": [SqlQuery], "totalCount": <int> }`.
+
+## curl quick reference
+
+```bash
+# 1. token
+TOKEN=$(curl -s -X POST "$PLATFORM/connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=password&username=$USER&password=$PASS" | jq -r .access_token)
+
+# 2. list runnable reports
+curl -s -X POST "$PLATFORM/api/sql-queries/reports" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"keyword":"orders","take":50}'
+
+# 3. run a report for rows
+curl -s -X POST "$PLATFORM/api/sql-queries/execute-query/$ID" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"parameters":[{"name":"FromDate","type":"DateTime","value":"2026-01-01"}],"maxRows":100}'
+
+# 4. export to xlsx (note: bare array body)
+curl -s -X POST "$PLATFORM/api/sql-queries/execute/$ID/xlsx" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '[{"name":"FromDate","type":"DateTime","value":"2026-01-01"}]' \
+  -o report.xlsx
+```
+
+## PowerShell quick reference (Windows)
+
+```powershell
+$body = "grant_type=password&username=$env:VC_USER&password=$env:VC_PASS"
+$token = (Invoke-RestMethod -Method Post -Uri "$Platform/connect/token" `
+  -ContentType "application/x-www-form-urlencoded" -Body $body).access_token
+$headers = @{ Authorization = "Bearer $token" }
+
+# run a report for rows
+Invoke-RestMethod -Method Post -Uri "$Platform/api/sql-queries/execute-query/$id" `
+  -Headers $headers -ContentType "application/json" `
+  -Body '{"parameters":[{"name":"FromDate","type":"DateTime","value":"2026-01-01"}],"maxRows":100}'
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# Claude Code guidance — vc-module-sql-queries
+
+This repo ships two project-scoped skills under `.claude/skills/` for automating the
+SQL Queries module's reporting via its REST API. Both are grounded in the module source
+(controller routes, model field names, and the `sql-queries:*` permissions).
+
+## Which skill to use
+
+Pick by **intent**, not by who the user is:
+
+- **vc-sql-queries-admin** — *authoring & lifecycle.* Use when the request is to **create,
+  edit, test/preview, search, or delete** saved reports, or to write/validate SQL.
+  Needs `sql-queries:create` / `:update` / `:delete` / `:read`.
+  Cues: "create a report", "add a parameter", "test this query before saving", "delete the
+  old report".
+
+- **vc-sql-queries-business** — *run & export only.* Use when the request is to **get data
+  from a report that already exists**: find it, run it with values, read the rows, export to
+  CSV/XLSX/PDF/HTML. Needs `sql-queries:access` + `sql-queries:read`. Never writes SQL.
+  Cues: "run the X report", "what does the orders report show", "export that to Excel".
+
+If a "run" request can't be satisfied because no matching report exists, the business skill
+hands off: it tells the user to ask an admin (use vc-sql-queries-admin) to create one.
+
+## Shared rules that apply to both
+
+- Reports run against a **read-only** connection string prefixed `SqlQueries.` — never author
+  or run mutating SQL or DDL.
+- Parameterize inputs; never string-concatenate values into the query text.
+- Always send every declared parameter in a run/preview/export request — dropping one fails
+  with `Must declare the scalar variable @<name>`. A blank/`null` value is fine: the backend
+  substitutes a type default (`DateTime` → today, `Integer`/`Decimal` → `0`, `Boolean` →
+  `false`), so an unset `DateTime` no longer causes a `SqlDateTime overflow`. A blank therefore
+  means "use the default", not SQL `NULL`; a `(@FromDate IS NULL OR …)` guard is still sound
+  defensive practice but won't return "all rows" for a blank date.
+- The bearer token is a secret — never print, log, or save it.
+- Confirm before persisted/destructive actions (create/update/delete) and before exporting a file.
+
+## Environment setup (expected, configure locally — do not commit secrets)
+
+Set these as environment variables or via your local Claude Code config; do not hard-code
+them in the repo:
+
+- `VC_PLATFORM_URL` — base platform URL (e.g. `https://localhost:5001`)
+- `VC_USER`, `VC_PASS` — credentials used to obtain a bearer token
+
+A read-only connection string named with the `SqlQueries.` prefix must exist in the platform
+configuration before reports can run.
+
+See each skill's `references/api.md` for the full endpoint table, model shapes, and
+curl/PowerShell snippets.

--- a/README.md
+++ b/README.md
@@ -5,24 +5,12 @@ This module is designed to empower administrators and developers by providing a 
 * Execute custom SQL queries against the VirtoCommerce databases.
 * Integrate with the platform’s security and permissions system to control query access.
 * Return results in user-friendly formats for reporting and analysis: HTML, PDF, CSV, XLSX.
-* Supports query parameters: Short Text, Dare Time, Boolean, Integer, Deceimal.
+* Supports query parameters: Short Text, Date Time, Boolean, Integer, Decimal.
 * Supports multiple database providers: SQL Server (default), MySQL, and PostgreSQL.
 * Supports multiple connection strings.
 * Platform Backup & Restore support.
 
-## Backup & Restore
 
-SQL queries are included in the platform-wide backup and restore process.
-
-When you run a platform export, all SQL queries (Name, Description, Query text, Connection string name and Parameters) are serialized into the backup archive.
-
-On import, the queries are recreated or updated, preserving their identifiers, metadata and parameter definitions.
-
-To run backup/restore:
-1. Open Virto Commerce Admin UI.
-1. Navigate to **Settings → Platform → Export** (or **Import**).
-1. Ensure **Sql Queries** module is selected in the module list.
-1. Run the export/import process.
 
 ## Screenshots
 ### No SQL queries yet
@@ -129,6 +117,38 @@ The module registers the following permissions:
 * sql-queries:delete
   
 Assign these permissions to appropriate roles/users to manage access.
+
+## Claude Code skills
+
+This repo ships two project-scoped [Claude Code](https://claude.com/claude-code) skills under
+`.claude/skills/` that automate the module's reporting through its REST API. Pick by intent:
+
+* **vc-sql-queries-admin** — *authoring & lifecycle.* Create, edit, test/preview, search, or
+  delete saved reports and write/validate SQL. Requires `sql-queries:create` / `:update` /
+  `:delete` / `:read`.
+* **vc-sql-queries-business** — *run & export only.* Find an existing report, run it with
+  parameter values, read the rows, and export to CSV / XLSX / PDF / HTML. Requires
+  `sql-queries:access` + `sql-queries:read`. Never writes SQL.
+
+Both skills are grounded in the module source (controller routes, model field names, and the
+`sql-queries:*` permissions) and enforce the module's safety rules: read-only `SqlQueries.`-prefixed
+connections only, fully parameterized inputs, and a live preview before any report is saved.
+See each skill's `references/api.md` for the full endpoint table and request/response shapes,
+and the repo `CLAUDE.md` for shared rules and local environment setup.
+
+## Backup & Restore
+
+SQL queries are included in the platform-wide backup and restore process.
+
+When you run a platform export, all SQL queries (Name, Description, Query text, Connection string name and Parameters) are serialized into the backup archive.
+
+On import, the queries are recreated or updated, preserving their identifiers, metadata and parameter definitions.
+
+To run backup/restore:
+1. Open Virto Commerce Admin UI.
+1. Navigate to **Settings → Platform → Export** (or **Import**).
+1. Ensure **Sql Queries** module is selected in the module list.
+1. Run the export/import process.
 
 ## Documentation
 * [View on GitHub](https://github.com/VirtoCommerce/vc-module-sql-queries)


### PR DESCRIPTION
## Description
feat: Added two project-scoped skills under .claude/skills/ for automating the SQL Queries module's reporting via its REST API.

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.SqlQueries_3.1003.0-pr-15-46da.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent skill definitions only; no module runtime or API behavior changes.
> 
> **Overview**
> Adds **Claude Code** automation for the SQL Queries module: two repo-scoped skills under `.claude/skills/` plus root **`CLAUDE.md`** and a live-demo script **`DEMO.md`**.
> 
> **`vc-sql-queries-admin`** drives report authoring (discover DB via `database-information`, preview with `execute-preview`, confirm, then create/update/delete) with read-only `SqlQueries.*` connections, parameterized SQL only, and mandatory inclusion of every declared parameter (blank values → type defaults, not omitted). **`vc-sql-queries-business`** only lists, runs (`execute-query`), and exports (`execute/{id}/{format}` with a bare JSON parameter array), with export confirmation and no SQL authoring.
> 
> Each skill ships a **`references/api.md`** aligned to the module REST API (permissions, models, curl/PowerShell). **`README.md`** gains a Claude skills section and typo fixes; Backup & Restore is moved below that section without changing its content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46da99e305a91f3e4a8a1eeb8924e58477d800b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->